### PR TITLE
Comment out ormReload by default in test harness

### DIFF
--- a/test-harness/Application.cfc
+++ b/test-harness/Application.cfc
@@ -78,7 +78,8 @@ component{
 			if( server.keyExists( "lucee" ) ){
 				pagePoolClear();
 			}
-			ormReload();
+			// ORM reload: ENABLE IF NEEDED
+			// ormReload();
 		}
 
 		// Process ColdBox Request


### PR DESCRIPTION
We shouldn't have an ORMReload by default if ORM is not enabled by default.