### PR TITLE
🐛 FIX: Correct task file run on case-sensitive systems

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,10 @@
 This template can be used to create Ortus based ColdBox Modules.  To use, just click the `Use this Template` button in the github repository: https://github.com/coldbox-modules/module-template and run the setup task from where you cloned it.
 
 ```bash
-box task run taskFile=build/setupTemplate
+box task run taskFile=build/SetupTemplate
 ```
 
-The `setupTemplate` task will ask you for your module name, id and description and configure the template for you! Enjoy!
+The `SetupTemplate` task will ask you for your module name, id and description and configure the template for you! Enjoy!
 
 ## Directory Structure
 


### PR DESCRIPTION
Fixes filename casing error on case-sensitive file systems:

```bash
CommandBox> task run taskFile=build/setupTemplate

ERROR: Task CFC doesn't exist.
```