### PR TITLE
Bugfix: Check if ColdboxVirtualApp Exists Before Shutdown

### DIFF
--- a/test-harness/tests/Application.cfc
+++ b/test-harness/tests/Application.cfc
@@ -74,7 +74,9 @@ component{
 	}
 
 	public void function onRequestEnd( required targetPage ) {
-		request.coldBoxVirtualApp.shutdown();
+		if ( request.keyExists(  "coldBoxVirtualApp" ) ) {
+            request.coldBoxVirtualApp.shutdown();
+        }
 	}
 
     private boolean function shouldEnableFullNullSupport() {

--- a/test-harness/tests/Application.cfc
+++ b/test-harness/tests/Application.cfc
@@ -75,8 +75,8 @@ component{
 
 	public void function onRequestEnd( required targetPage ) {
 		if ( request.keyExists( "coldBoxVirtualApp" ) ) {
-            request.coldBoxVirtualApp.shutdown();
-        }
+			request.coldBoxVirtualApp.shutdown();
+		}
 	}
 
     private boolean function shouldEnableFullNullSupport() {

--- a/test-harness/tests/Application.cfc
+++ b/test-harness/tests/Application.cfc
@@ -74,7 +74,7 @@ component{
 	}
 
 	public void function onRequestEnd( required targetPage ) {
-		if ( request.keyExists(  "coldBoxVirtualApp" ) ) {
+		if ( request.keyExists( "coldBoxVirtualApp" ) ) {
             request.coldBoxVirtualApp.shutdown();
         }
 	}


### PR DESCRIPTION
If you set `this.unLoadColdbox = true; ` in your tests, there won't be a `ColdboxVirtualApp` in the `request` scope and the page will throw an exception "The key [COLDBOXVIRTUALAPP] does not exist in the request scope, the structure is empty"

## Type of change

- [x] Bug Fix
## Checklist